### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,5 +1,8 @@
 name: Build Windows EXE
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/018929014/pyxdcc-cli/security/code-scanning/1](https://github.com/018929014/pyxdcc-cli/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block so the `GITHUB_TOKEN` used by this workflow does not inherit broad default permissions. We should grant only what the workflow actually needs: read access to repository contents for checkout and build, and write access to contents for creating a GitHub Release. No other GitHub scopes (issues, pull-requests, etc.) are used here.

The single best way to fix this without changing functionality is to add a `permissions` block at the workflow root (top-level, alongside `name` and `on`). This block will apply to all jobs unless they override it. Since the job uses `softprops/action-gh-release` to publish a release, the workflow needs `contents: write`; setting `contents: read` as CodeQL’s minimal example would break the release step. A suitable configuration is:

```yaml
permissions:
  contents: write
```

This keeps everything else at the implicit default of `none` while allowing releases to be created/updated. Concretely, in `.github/workflows/build-exe.yml`, insert the `permissions` block after the `name: Build Windows EXE` line and before the `on:` block. No imports or additional methods are required; this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
